### PR TITLE
Can now use convertUnit to round to 0 decimal places.

### DIFF
--- a/geolib.js
+++ b/geolib.js
@@ -510,7 +510,8 @@
 		 * Converts a distance from meters to km, mm, cm, mi, ft, in or yd
 		 *
 		 * @param		string		Format to be converted in
-		 * @param		float		Distance
+		 * @param		float		Distance in meters
+		 * @param               float           Decimal places for rounding (default: 4)
 		 * @return		float		Converted distance
 		 */
 		convertUnit: function(unit, distance, round) {
@@ -527,7 +528,7 @@
 			}
 
 			unit = unit || 'm';
-			round = round || 4;
+			round = (null == round ? 4 : round);
 
 			switch(unit) {
 


### PR DESCRIPTION
Nice library! I found a minor bug where convertUnit does not allow one to round to 0 decimal places. Fixed in this pull request.

Can now use **convertUnit** to round to 0 decimal places:

```
geolib.convertUnit('mi', 5000*1000, 0) === 3107
```

and

```
geolib.convertUnit('mi', 5000*1000) === 3106.856
```

while before it was incorrectly being rounded to 4 places instead of 0:

```
geolib.convertUnit('mi', 5000*1000, 0) === 3106.856
```

I generally recommend using 

```
arg = (null == arg ? DEFAULT : arg);
```

instead of

```
arg = arg || DEFAULT;
```

for giving default arguments in Javascript because that way you get the default for `null` and `undefined` items while keeping "falsy" items such as `0`, `false`, and `""`.
