### PR TITLE
geolib.js: allow negative lat/lng

### DIFF
--- a/geolib.js
+++ b/geolib.js
@@ -343,9 +343,9 @@
 
 			var useElevation = coords[0].hasOwnProperty(elevation);
 			var stats = {
-				maxLat: 0,
+				maxLat: -Infinity,
 				minLat: Infinity,
-				maxLng: 0,
+				maxLng: -Infinity,
 				minLng: Infinity
 			};
 


### PR DESCRIPTION
Allow negative lat and lng in getBounds (for coordinates in western and southern hemispheres).
Thanks for a useful library!
