### PR TITLE
Replaced standard call to 'throw' with an Error instance

### DIFF
--- a/geolib.js
+++ b/geolib.js
@@ -801,7 +801,7 @@
 			} else if(geolib.isSexagesimal(value) === true) {
 				return parseFloat(geolib.sexagesimal2decimal(value));
 			} else {
-				throw 'Unknown format.';
+				throw new Error('Unknown format.');
 			}
 
 		},


### PR DESCRIPTION
Replaced standard call to 'throw' with an Error instance so that a proper stack trace can be inspected when this exception occurs.
