### PR TITLE
Use Object.create() instead of Object()

### DIFF
--- a/src/geolib.js
+++ b/src/geolib.js
@@ -937,7 +937,7 @@
             for(var coord in coords) {
 
                 var distance = this.getDistance(latlng, coords[coord]);
-                var augmentedCoord = Object(coords[coord]);
+                var augmentedCoord = Object.create(coords[coord]);
                 augmentedCoord.distance = distance;
                 augmentedCoord.key = coord;
 


### PR DESCRIPTION
This bug drive me crazy. It cost me 2 hours to find out the issue. And finally I found it was coursed by missing "create" in cloning object.

PLEASE FIX IT AS SOON AS POSSIBLE.