### PR TITLE
Add TypeScript definitions to package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     }
   ],
   "files": [
+    "dist/geolib.d.ts",
     "dist/geolib.js",
     "dist/geolib.elevation.js"
   ],
@@ -47,6 +48,7 @@
   "scripts": {
     "test": "grunt travis --verbose"
   },
+  "typings": "dist/geolib.d.ts",
   "version": "2.0.21",
   "main": "dist/geolib.js"
 }


### PR DESCRIPTION
When installed from GitHub directly (`npm install manuelbieh/Geolib`) the package still does not include the TypeScript definitions. The file need to be added to `package.json` to be included and recognized by TypeScript compiler.