### PR TITLE
Fixes typescript (tsc) errors

### DIFF
--- a/dist/geolib.d.ts
+++ b/dist/geolib.d.ts
@@ -192,7 +192,7 @@ declare namespace geolib {
      * - in (inch)
      * - yd (yards)
     */
-    function convertUnit(unit: string, distance: number)
+    function convertUnit(unit: string, distance: number): number;
 
 
     /** Converts a given distance (in meters) to another unit. 
@@ -207,7 +207,7 @@ declare namespace geolib {
      * - in (inch)
      * - yd (yards)
     */
-    function convertUnit(unit: string, distance: number, round: number);
+    function convertUnit(unit: string, distance: number, round: number): number;
 
 
     /** Converts a sexagesimal coordinate to decimal format */


### PR DESCRIPTION
With the typescript definition files currently in master, compiling the project with tsc gives the following errors:
```
node_modules/geolib/dist/geolib.d.ts(195,14): error TS7010: 'convertUnit', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/geolib/dist/geolib.d.ts(210,14): error TS7010: 'convertUnit', which lacks return-type annotation, implicitly has an 'any' return type.
```
I set the return type to number to fix the issue.