### PR TITLE
Specify return type on `convertUnit` typings

### DIFF
--- a/dist/geolib.d.ts
+++ b/dist/geolib.d.ts
@@ -192,7 +192,7 @@ declare namespace geolib {
      * - in (inch)
      * - yd (yards)
     */
-    function convertUnit(unit: string, distance: number)
+    function convertUnit(unit: string, distance: number): number;
 
 
     /** Converts a given distance (in meters) to another unit. 
@@ -207,7 +207,7 @@ declare namespace geolib {
      * - in (inch)
      * - yd (yards)
     */
-    function convertUnit(unit: string, distance: number, round: number);
+    function convertUnit(unit: string, distance: number, round: number): number;
 
 
     /** Converts a sexagesimal coordinate to decimal format */


### PR DESCRIPTION
hey @manuelbieh -- I'd like to add a return type here to make the type definition more specific.

Thanks!
Alex