### PR TITLE
Change incorrect LGPL license to MIT

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "geo",
     "distance"
   ],
-  "license": "LGPL",
+  "license": "MIT",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
The bower.json file incorrectly states that the license for this package is LGPL.