### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ It returns maximum and minimum, latitude, longitude, and elevation (if provided)
 
 <h4>Example</h4>
 
-<pre>geolib.getCenter([
+<pre>geolib.getBounds([
          {latitude: 52.516272, longitude: 13.377722},
          {latitude: 51.515, longitude: 7.453619},
          {latitude: 51.503333, longitude: -0.119722}


### PR DESCRIPTION
Fix copy/paste typo for `getBounds` example in README file.