### PR TITLE
Add missing bearing to CompassDirection interface

### DIFF
--- a/dist/geolib.d.ts
+++ b/dist/geolib.d.ts
@@ -35,6 +35,7 @@ declare namespace geolib {
     export interface CompassDirection {
         rough: string,
         exact: string
+        bearing: number
     }
 
     export interface Distance {


### PR DESCRIPTION
Bearing has been added to the return value of getCompassDirection but not to the CompassDirection interface which causes typescript to not compile