### PR TITLE
Change from Object.create() to Object.assign()

### DIFF
--- a/dist/geolib.js
+++ b/dist/geolib.js
@@ -943,7 +943,7 @@
 
             var coordsArray = Object.keys(coords).map(function(idx) {
                 var distance = this.getDistance(latlng, coords[idx]);
-                var augmentedCoord = Object.create(coords[idx]);
+                var augmentedCoord = Object.assign({}, coords[idx]);
                 augmentedCoord.distance = distance;
                 augmentedCoord.key = idx;
                 return augmentedCoord;

--- a/src/geolib.js
+++ b/src/geolib.js
@@ -802,7 +802,7 @@
         orderByDistance: function(latlng, coords) {
             const coordsArray = Object.keys(coords).map(function(idx) {
                 const distance = this.getDistance(latlng, coords[idx]);
-                const augmentedCoord = Object.create(coords[idx]);
+                const augmentedCoord = Object.assign({}, coords[idx]);
                 augmentedCoord.distance = distance;
                 augmentedCoord.key = idx;
                 return augmentedCoord;


### PR DESCRIPTION
Object.create() creates a new object, assigning the properties of argument object to prototype. This prototype is lost if the object is passed in the response of express or any HTTP server response. Object.assign() will retain all properties in the new object which can be easily serialized via JSON and sent as a response.