### PR TITLE
Remove module type in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "typings": "es/index.d.ts",
-  "type": "module",
   "files": [
     "lib",
     "es"


### PR DESCRIPTION
When requiring the module using `Node@12.11.0`, it doesn't matter whether it is via require, or [babel](https://babeljs.org/) `import`, it's the user to use `import` to get this module, because it's defined (via `package.json`) as a ES module.

This might lead to some issues when using libraries such as [@babel/register](https://npm.im/@babel/register) or even when using node without the experimental [ECMAScript Modules](https://nodejs.org/api/esm.html) feature.

By removing it, the module requiring works again.