### PR TITLE
Bugfix: isPointWithinRadius false even if true

### DIFF
--- a/src/isPointWithinRadius.test.js
+++ b/src/isPointWithinRadius.test.js
@@ -20,4 +20,14 @@ describe('isPointWithinRadius', () => {
             )
         ).toBe(false);
     });
+
+    it('should return true if a given point is within a certain radius with high accuracy', () => {
+        expect(
+            isPointWithinRadius(
+                { latitude: 42.53098, longitude: -71.28029 },
+                { latitude: 42.53101, longitude: -71.2803986 },
+                10
+            )
+        ).toBe(true);
+    });
 });

--- a/src/isPointWithinRadius.ts
+++ b/src/isPointWithinRadius.ts
@@ -7,7 +7,8 @@ const isPointWithinRadius = (
     center: GeolibInputCoordinates,
     radius: number
 ) => {
-    return getDistance(point, center) < radius;
+    const accuracy = 0.01;
+    return getDistance(point, center, accuracy) < radius;
 };
 
 export default isPointWithinRadius;


### PR DESCRIPTION
Because this function calls getDistance() without an accuracy value, it rounds up to the nearest meter.

Closes https://github.com/manuelbieh/geolib/issues/247.