### PR TITLE
Added Changes in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ This function takes up to 3 arguments. First 2 arguments must be valid `GeolibIn
 
 ```js
 getDistance(
-    { latitude: 51.5103, longitude: 7.49347 },
-    { latitude: "51° 31' N", longitude: "7° 28' E" }
+    { latitude: 51.5103, longitude: 7.49347 }, //Latitude and longitude are in Radian 
+    { latitude: "51° 31' N", longitude: "7° 28' E" }//Latitude and longitude are in Degree
 );
+//Radian and degree both are supported you can use according to your use case
 ```
 
 ```js
@@ -110,9 +111,10 @@ It takes the same (up to 3) arguments as `getDistance`.
 
 ```js
 geolib.getPreciseDistance(
-    { latitude: 51.5103, longitude: 7.49347 },
-    { latitude: "51° 31' N", longitude: "7° 28' E" }
+    { latitude: 51.5103, longitude: 7.49347 }, //Latitude and longitude are in Radian 
+    { latitude: "51° 31' N", longitude: "7° 28' E" } //Latitude and longitude are in Degree
 );
+//Radian and degree both are supported you can use according to your use case
 ```
 
 ### `getCenter(coords)`


### PR DESCRIPTION
I have added getDistance and getPreciseDistance that users can use both radian or degree according to his/her use case. So he/she does not get confused that the First parameter should be in radian and the second param is in degree.