### PR TITLE
Add GeolibBounds type

### DIFF
--- a/src/getBounds.ts
+++ b/src/getBounds.ts
@@ -1,8 +1,9 @@
 import getLatitude from './getLatitude';
 import getLongitude from './getLongitude';
+import { GeolibBounds, GeolibInputCoordinates } from './types';
 
 // Gets the max and min, latitude and longitude
-const getBounds = (points: any[]) => {
+const getBounds = (points: GeolibInputCoordinates[]): GeolibBounds => {
     if (Array.isArray(points) === false || points.length === 0) {
         throw new Error('No points were given.');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,3 +43,10 @@ export type Timestamp = number;
 export type GeolibInputCoordinatesWithTime = GeolibInputCoordinates & {
     time: Timestamp;
 };
+
+export type GeolibBounds = {
+    maxLat: number;
+    minLat: number;
+    maxLng: number;
+    minLng: number;
+};


### PR DESCRIPTION
I noticed that the getBounds function accepts `any[]` and returns `any` according to current definitions. This pull request tightens up that definition to make it more type-safe.