### PR TITLE
fix: make native ESM importing from Node.js work

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,15 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "typings": "es/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./lib/index.js",
+      "default": "./es/index.js"
+    },
+    "./es/*": "./es/*.js",
+    "./lib/*": "./lib/*.js",
+    "./package.json": "./package.json"
+  },
   "files": [
     "lib",
     "es"


### PR DESCRIPTION
This is a backwards compatible patch to make importing from Node.js in native ESM mode work. The reason this adds all of the files as valid import targets is to make sure that any import that worked before still works now.