### PR TITLE
Make sexagesimalToDecimal() trim whitespace

### DIFF
--- a/src/sexagesimalToDecimal.ts
+++ b/src/sexagesimalToDecimal.ts
@@ -2,7 +2,7 @@ import { sexagesimalPattern } from './constants';
 
 // Converts a sexagesimal coordinate to decimal format
 const sexagesimalToDecimal = (sexagesimal: any) => {
-    const data = new RegExp(sexagesimalPattern).exec(sexagesimal);
+    const data = new RegExp(sexagesimalPattern).exec(sexagesimal.toString().trim());
 
     if (typeof data === 'undefined' || data === null) {
         throw new Error('Given value is not in sexagesimal format');


### PR DESCRIPTION
This is for consistency with `isSexagesimal()`, which `trim()` (starting & trailing whitespaces) from its input.

Fixes #254.