### PR TITLE
Improve orderByDistance with type generics

### DIFF
--- a/src/orderByDistance.ts
+++ b/src/orderByDistance.ts
@@ -7,9 +7,9 @@ type DistanceFn = (
 ) => number;
 
 // Sorts an array of coords by distance from a reference coordinate
-const orderByDistance = (
+const orderByDistance = <T extends GeolibInputCoordinates>(
     point: GeolibInputCoordinates,
-    coords: GeolibInputCoordinates[],
+    coords: T[],
     distanceFn: DistanceFn = getDistance
 ) => {
     distanceFn = typeof distanceFn === 'function' ? distanceFn : getDistance;


### PR DESCRIPTION
This change adds a generic type to the `orderByDistance` function.
It is not a breaking change, and only allows easier usage of the function.
Specifically, the function was previously typed as returning `GeolibInputCoordinates[]` which is a type that includes all the different ways of representing coordinates, with no respect to which specific type the passed input coordinates actually have.
This was hard to use and not always complete as extra data could be added to the elements of the input coordinate array. This extra data would still be in the result of the function, but would not be in its return type.

Here is an examle of what this change makes possible:
```ts
type CoordinatesAndExtraData = {
  lat: string, lon: string, locationName: string
};
// ... any data loaded here
let points: CoordinatesAndExtraData = generateSomeData();
let targetPoint: GeolibInputCoordinates = generateTargetPoint(); 
// Generate ordered list
let ordered = orderByDistance(targetPoint, points);
// This works but was previously disallowed by the types as locationName doesn't exist on `GeolibInputCoordinates`
console.log("The first point in the ordered list is "+ordered[0].locationName)
```