### PR TITLE
deleted an extra closing paranthesis in the funtion

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Converts the result from `getSpeed` into a more human friendly format. Currently
 -   mph (miles per hour)
 
 ```js
-geolib.convertSpeed(29.8678, 'kmh'));
+geolib.convertSpeed(29.8678, 'kmh');
 ```
 
 Returns the converted value as number.


### PR DESCRIPTION
There was an unnecessary closing parenthesis that's deleted.