### PR TITLE
Add `types` condition to the `require` condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
   "typings": "es/index.d.ts",
   "exports": {
     ".": {
-      "require": "./lib/index.js",
+      "require": {
+        "types": "./es/index.d.ts",
+        "default": "./lib/index.js"
+      },
       "default": "./es/index.js"
     },
     "./es/*": "./es/*.js",


### PR DESCRIPTION
Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

You can check the reported error [here](https://arethetypeswrong.github.io/?p=geolib%403.3.3)