### PR TITLE
test/fix: Added test coverage and made fixed to getRoughCompassDirection

### DIFF
--- a/src/findNearest.test.js
+++ b/src/findNearest.test.js
@@ -1,0 +1,16 @@
+import findNearest from './findNearest';
+
+describe('findNearest', () => {
+    it('returns first result from orderByDistance', () => {
+        const point = { latitude: 51.516241842, longitude: 7.456494328 };
+        const nearest = { latitude: 51.515400598, longitude: 7.45518541 };
+        const coords = [
+            { latitude: 51.513357512, longitude: 7.45574331 },
+            nearest,
+            { latitude: 51.516722545, longitude: 7.459863183 },
+            { latitude: 51.517443592, longitude: 7.463232037 },
+        ];
+
+        expect(findNearest(point, coords)).toEqual(nearest);
+    });
+});

--- a/src/getRoughCompassDirection.test.js
+++ b/src/getRoughCompassDirection.test.js
@@ -1,0 +1,40 @@
+import getRoughCompassDirection from './getRoughCompassDirection';
+
+describe('getRoughCompassDirection', () => {
+    describe('when exact compass direction is Northern', () => {
+        it('returns N', () => {
+            ['NNE', 'NE', 'NNW', 'N'].forEach((exactCompassDirection) => {
+                expect(getRoughCompassDirection(exactCompassDirection)).toEqual(
+                    'N'
+                );
+            });
+        });
+    });
+    describe('when exact compass direction is Eastern', () => {
+        it('returns E', () => {
+            ['ENE', 'E', 'ESE', 'SE'].forEach((exactCompassDirection) => {
+                expect(getRoughCompassDirection(exactCompassDirection)).toEqual(
+                    'E'
+                );
+            });
+        });
+    });
+    describe('when exact compass direction is Southern', () => {
+        it('returns S', () => {
+            ['SSE', 'S', 'SSW', 'SW'].forEach((exactCompassDirection) => {
+                expect(getRoughCompassDirection(exactCompassDirection)).toEqual(
+                    'S'
+                );
+            });
+        });
+    });
+    describe('when exact compass direction is Western', () => {
+        it('returns W', () => {
+            ['WSW', 'W', 'WNW', 'NW'].forEach((exactCompassDirection) => {
+                expect(getRoughCompassDirection(exactCompassDirection)).toEqual(
+                    'W'
+                );
+            });
+        });
+    });
+});

--- a/src/getRoughCompassDirection.ts
+++ b/src/getRoughCompassDirection.ts
@@ -1,19 +1,19 @@
 // Receives an exact compass direction (like WNW) and spits out a very rough
 // and overly simplified direction (N|E|S|W). Use with caution!
 const getRoughCompassDirection = (exact: string) => {
-    if (/^NNE|NE|NNW|N$/.test(exact)) {
+    if (/^(NNE|NE|NNW|N)$/.test(exact)) {
         return 'N';
     }
 
-    if (/^ENE|E|ESE|SE$/.test(exact)) {
+    if (/^(ENE|E|ESE|SE)$/.test(exact)) {
         return 'E';
     }
 
-    if (/^SSE|S|SSW|SW$/.test(exact)) {
+    if (/^(SSE|S|SSW|SW)$/.test(exact)) {
         return 'S';
     }
 
-    if (/^WSW|W|WNW|NW$/.test(exact)) {
+    if (/^(WSW|W|WNW|NW)$/.test(exact)) {
         return 'W';
     }
 };

--- a/src/isValidLatitude.test.js
+++ b/src/isValidLatitude.test.js
@@ -1,0 +1,43 @@
+import isValidLatitude from './isValidLatitude';
+import { MAXLAT, MINLAT } from './constants';
+
+describe('isValidLatitude', () => {
+    describe('when value is a decimal', () => {
+        describe('when value is between MINLAT and MAXLAT', () => {
+            it('returns true', () => {
+                let value = MAXLAT - 1;
+                expect(isValidLatitude(value)).toEqual(true);
+                value = MINLAT + 1;
+                expect(isValidLatitude(value)).toEqual(true);
+            });
+        });
+        describe('when value is not between MINLAT and MAXLAT', () => {
+            it('returns false', () => {
+                let value = MAXLAT + 1;
+                expect(isValidLatitude(value)).toEqual(false);
+                value = MINLAT - 1;
+                expect(isValidLatitude(value)).toEqual(false);
+            });
+        });
+    });
+    describe('when value is a sexagesimal', () => {
+        describe('when value is between MINLAT and MAXLAT', () => {
+            it('returns true', () => {
+                const value = '51° 31\' 10.11" N';
+                expect(isValidLatitude(value)).toEqual(true);
+            });
+        });
+        describe('when value is not between MINLAT and MAXLAT', () => {
+            it('returns false', () => {
+                const value = '121°26′31″W';
+                expect(isValidLatitude(value)).toEqual(false);
+            });
+        });
+    });
+    describe('when value is not a decimal or sexagesimal', () => {
+        it('returns false', () => {
+            const value = 'foo';
+            expect(isValidLatitude(value)).toEqual(false);
+        });
+    });
+});

--- a/src/isValidLatitude.ts
+++ b/src/isValidLatitude.ts
@@ -3,7 +3,6 @@ import isSexagesimal from './isSexagesimal';
 import sexagesimalToDecimal from './sexagesimalToDecimal';
 import { MAXLAT, MINLAT } from './constants';
 
-// TODO: Add tests
 const isValidLatitude = (value: any): boolean => {
     if (isDecimal(value)) {
         if (parseFloat(value) > MAXLAT || value < MINLAT) {

--- a/src/isValidLongitude.test.js
+++ b/src/isValidLongitude.test.js
@@ -1,0 +1,43 @@
+import isValidLongitude from './isValidLongitude';
+import { MAXLON, MINLON } from './constants';
+
+describe('isValidLongitude', () => {
+    describe('when value is a decimal', () => {
+        describe('when value is between MINLON and MAXLON', () => {
+            it('returns true', () => {
+                let value = MAXLON - 1;
+                expect(isValidLongitude(value)).toEqual(true);
+                value = MINLON + 1;
+                expect(isValidLongitude(value)).toEqual(true);
+            });
+        });
+        describe('when value is not between MINLON and MAXLON', () => {
+            it('returns false', () => {
+                let value = MAXLON + 1;
+                expect(isValidLongitude(value)).toEqual(false);
+                value = MINLON - 1;
+                expect(isValidLongitude(value)).toEqual(false);
+            });
+        });
+    });
+    describe('when value is a sexagesimal', () => {
+        describe('when value is between MINLON and MAXLON', () => {
+            it('returns true', () => {
+                const value = '51° 31\' 10.11" N';
+                expect(isValidLongitude(value)).toEqual(true);
+            });
+        });
+        describe('when value is not between MINLON and MAXLON', () => {
+            it('returns false', () => {
+                const value = '221°26′31″W';
+                expect(isValidLongitude(value)).toEqual(false);
+            });
+        });
+    });
+    describe('when value is not a decimal or sexagesimal', () => {
+        it('returns false', () => {
+            const value = 'foo';
+            expect(isValidLongitude(value)).toEqual(false);
+        });
+    });
+});

--- a/src/isValidLongitude.ts
+++ b/src/isValidLongitude.ts
@@ -3,7 +3,6 @@ import isSexagesimal from './isSexagesimal';
 import sexagesimalToDecimal from './sexagesimalToDecimal';
 import { MAXLON, MINLON } from './constants';
 
-// TODO: Add tests
 const isValidLongitude = (value: any): boolean => {
     if (isDecimal(value)) {
         if (parseFloat(value) > MAXLON || value < MINLON) {

--- a/src/toDeg.test.js
+++ b/src/toDeg.test.js
@@ -1,0 +1,7 @@
+import toDeg from './toDeg';
+
+describe('toDeg', () => {
+    it('converts a value to a degree', () => {
+        expect(toDeg(35.238965)).toEqual(2019.0439689092252);
+    });
+});

--- a/src/toRad.test.js
+++ b/src/toRad.test.js
@@ -1,0 +1,7 @@
+import toRad from './toRad';
+
+describe('toRad', () => {
+    it('converts a value to a radian', () => {
+        expect(toRad(2019.0439689092252)).toEqual(35.238965);
+    });
+});


### PR DESCRIPTION
Hey guys, thought I chip in and add some test coverage. Along way I encountered what seemed to be a bug and fixed that. Please let me know of any changes that should made.

Add test coverage to the following files:

- findNearest.ts
- getRoughCompassDirection.ts
- isValidLatitude.ts
- isValidLongitude.ts
- toDeg.ts
- toRad.ts

Made fixes to src/getRoughCompassDirection.ts:

What was happening here was the Regular expression would validate as true if string contained the value rather than matched exactly with value. For example, `/^NNE|NE|NNW|N$/` would return `N` for `ENE` because `ENE` contains `NE`. The fix was to alter the regex so it performs a strict match rather than "contains".