### PR TITLE
perf: optimize getDistance

### DIFF
--- a/src/getDistance.ts
+++ b/src/getDistance.ts
@@ -15,18 +15,15 @@ const getDistance = (
     accuracy =
         typeof accuracy !== 'undefined' && !isNaN(accuracy) ? accuracy : 1;
 
-    const fromLat = getLatitude(from);
-    const fromLon = getLongitude(from);
-    const toLat = getLatitude(to);
-    const toLon = getLongitude(to);
+    const fromLat = toRad(getLatitude(from));
+    const toLat = toRad(getLatitude(to));
+    const deltaLon = toRad(getLongitude(from) - getLongitude(to));
 
     const distance =
         Math.acos(
             robustAcos(
-                Math.sin(toRad(toLat)) * Math.sin(toRad(fromLat)) +
-                    Math.cos(toRad(toLat)) *
-                        Math.cos(toRad(fromLat)) *
-                        Math.cos(toRad(fromLon) - toRad(toLon))
+                Math.sin(toLat) * Math.sin(fromLat) +
+                    Math.cos(toLat) * Math.cos(fromLat) * Math.cos(deltaLon)
             )
         ) * earthRadius;
 


### PR DESCRIPTION
Calling toRad upfront reduces the number of calls from 6 to 3.

[Perf test](https://jsperf.app/haversine-vs-spherical-law-of-cosines-vs-equirectangula/10) show that the updated version is a little over 1% faster. That's not much but still better.

Thanks for your great lib!